### PR TITLE
chore(namespace): bind clnrm to chatmangpt.com

### DIFF
--- a/.chatmangpt/namespace.toml
+++ b/.chatmangpt/namespace.toml
@@ -1,0 +1,35 @@
+schema_version = "1.0.0"
+namespace_version = "26.7.29"
+
+[namespace]
+origin = "https://chatmangpt.com"
+vocabulary = "https://chatmangpt.com/ns#"
+identifier_base = "https://chatmangpt.com/id/"
+registry_id = "https://chatmangpt.com/id/namespace/26.7.29"
+registry_repository = "seanchatmangpt/chatmangpt"
+registry_pr = 44
+
+[repository]
+id = "https://chatmangpt.com/id/repository/seanchatmangpt/clnrm"
+full_name = "seanchatmangpt/clnrm"
+source_url = "https://github.com/seanchatmangpt/clnrm"
+kind = "system"
+family = "verification"
+admission_basis = "readme"
+standing = "UNKNOWN"
+
+[public_object]
+id = "https://chatmangpt.com/id/system/clnrm"
+canonical_path = "/systems/clnrm"
+canonical_url = "https://chatmangpt.com/systems/clnrm"
+source_repository = "https://chatmangpt.com/id/repository/seanchatmangpt/clnrm"
+publish = true
+admission = "ADMITTED"
+standing = "UNKNOWN"
+description = "Hermetic integration testing framework using gVisor and Docker."
+
+[law]
+repository_is_identity = false
+metadata_implies_standing = false
+unknown_may_claim_alive = false
+receipt_required_for_actuation_claim = true


### PR DESCRIPTION
Adds `.chatmangpt/namespace.toml` for namespace version `26.7.29`, separating repository provenance, stable public identity, and the canonical human route. Standing remains `UNKNOWN`; this PR makes no runtime, deployment, or `ALIVE` claim. Scope is one metadata file with no generated or runtime changes. Depends on `seanchatmangpt/chatmangpt` draft PR #44. The exact manifest was parsed as TOML before publication.