### PR TITLE
ci(transport): manufacture offline MFW GMRW verifier

### DIFF
--- a/.github/mfw-gmrw-transport-trigger
+++ b/.github/mfw-gmrw-transport-trigger
@@ -1,0 +1,1 @@
+mfw-gmrw-offline-transport-v1

--- a/.github/workflows/mfw-gmrw-offline-source-transport.yml
+++ b/.github/workflows/mfw-gmrw-offline-source-transport.yml
@@ -1,0 +1,157 @@
+name: MFW GMRW Offline Source Transport
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/mfw-gmrw-offline-source-transport.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mfw-gmrw-offline-source-transport-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manufacture:
+    name: transport/offline-source-bundle
+    runs-on: windows-2025
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Create bundle root
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\mfw-offline\src" | Out-Null
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\mfw-offline\toolchains" | Out-Null
+
+      - name: Seal exact ggen source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: seanchatmangpt/ggen
+          ref: dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59
+          fetch-depth: 1
+          path: mfw-offline/src/ggen
+
+      - name: Seal exact sibling source graph
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = "$env:GITHUB_WORKSPACE\mfw-offline\src"
+          $repos = @(
+            @{ Name = 'lsp-max'; Sha = '7bcc1e16dec71ef5fb2cedea2dfd6cb5cde37f59' },
+            @{ Name = 'lsp-types-max'; Sha = '6773e6017ca83c565785d0ec39d75304f62c3237' },
+            @{ Name = 'wasm4pm'; Sha = '0bb134b29245517ac4969a9f1916f5432931c5d0' },
+            @{ Name = 'wasm4pm-compat'; Sha = 'e46155e209a750fda0218532d96ae17a9e10903e' }
+          )
+          foreach ($entry in $repos) {
+            $dest = Join-Path $root $entry.Name
+            git init -q $dest
+            git -C $dest remote add origin "https://github.com/seanchatmangpt/$($entry.Name).git"
+            git -C $dest fetch -q --depth 1 origin $entry.Sha
+            git -C $dest checkout -q FETCH_HEAD
+            $actual = git -C $dest rev-parse HEAD
+            if ($actual -ne $entry.Sha) { throw "source seal mismatch for $($entry.Name): $actual" }
+          }
+          $ggen = git -C (Join-Path $root 'ggen') rev-parse HEAD
+          if ($ggen -ne 'dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59') { throw "ggen seal mismatch: $ggen" }
+
+      - name: Install exact ggen build toolchain
+        run: |
+          $ErrorActionPreference = 'Stop'
+          rustup toolchain install nightly-2026-06-22 --profile minimal
+          rustup run nightly-2026-06-22 rustc --version --verbose
+          rustup run nightly-2026-06-22 cargo --version
+
+      - name: Vendor exact ggen dependency graph
+        env:
+          RUSTC_WRAPPER: ''
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundle = "$env:GITHUB_WORKSPACE\mfw-offline"
+          $ggen = "$bundle\src\ggen"
+          Push-Location $ggen
+          try {
+            $config = rustup run nightly-2026-06-22 cargo vendor --locked "$bundle\ggen-vendor"
+            [System.IO.File]::WriteAllLines("$bundle\ggen-vendor-config.toml", $config)
+          } finally {
+            Pop-Location
+          }
+
+      - name: Vendor exact MFW PCP dependency closure
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundle = "$env:GITHUB_WORKSPACE\mfw-offline"
+          $closure = "$bundle\mfw-closure"
+          New-Item -ItemType Directory -Force -Path "$closure\src" | Out-Null
+          @'
+          [package]
+          name = "mfw-gmrw-offline-deps"
+          version = "0.0.0"
+          edition = "2021"
+          rust-version = "1.82"
+
+          [dependencies]
+          blake3 = "=1.8.2"
+          serde = { version = "=1.0.228", features = ["derive"] }
+          serde_json = "=1.0.150"
+          thiserror = "=2.0.18"
+          '@ | Set-Content -Encoding utf8 "$closure\Cargo.toml"
+          'fn main() {}' | Set-Content -Encoding utf8 "$closure\src\main.rs"
+          rustup run nightly-2026-06-22 cargo generate-lockfile --manifest-path "$closure\Cargo.toml"
+          $config = rustup run nightly-2026-06-22 cargo vendor --locked --manifest-path "$closure\Cargo.toml" "$bundle\mfw-vendor"
+          [System.IO.File]::WriteAllLines("$bundle\mfw-vendor-config.toml", $config)
+
+      - name: Download exact Linux toolchains
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dest = "$env:GITHUB_WORKSPACE\mfw-offline\toolchains"
+          $assets = @(
+            'https://static.rust-lang.org/dist/rust-1.82.0-x86_64-unknown-linux-gnu.tar.xz',
+            'https://static.rust-lang.org/dist/2026-06-22/rust-nightly-x86_64-unknown-linux-gnu.tar.xz'
+          )
+          foreach ($url in $assets) {
+            $name = Split-Path $url -Leaf
+            $path = Join-Path $dest $name
+            Invoke-WebRequest -Uri $url -OutFile $path
+            Invoke-WebRequest -Uri "$url.sha256" -OutFile "$path.sha256"
+            $expected = ((Get-Content "$path.sha256") -split '\s+')[0].ToLowerInvariant()
+            $actual = (Get-FileHash -Algorithm SHA256 $path).Hash.ToLowerInvariant()
+            if ($actual -ne $expected) { throw "SHA-256 mismatch for $name" }
+          }
+
+      - name: Remove Git transport metadata
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Get-ChildItem "$env:GITHUB_WORKSPACE\mfw-offline\src" -Directory -Recurse -Force -Filter .git |
+            Sort-Object FullName -Descending |
+            Remove-Item -Recurse -Force
+
+      - name: Manufacture deterministic manifest
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = "$env:GITHUB_WORKSPACE\mfw-offline"
+          $records = Get-ChildItem $root -File -Recurse | Sort-Object FullName | ForEach-Object {
+            [ordered]@{
+              path = $_.FullName.Substring($root.Length + 1).Replace('\', '/')
+              bytes = $_.Length
+              sha256 = (Get-FileHash -Algorithm SHA256 $_.FullName).Hash.ToLowerInvariant()
+            }
+          }
+          [ordered]@{
+            schema = 'mfw.gmrw.offline-source-bundle.v1'
+            ggen_revision = 'dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59'
+            rust_stable = '1.82.0'
+            rust_nightly = 'nightly-2026-06-22'
+            files = $records
+          } | ConvertTo-Json -Depth 5 | Set-Content -Encoding utf8 "$root\MANIFEST.json"
+
+      - name: Upload sealed offline source bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mfw-gmrw-offline-source-${{ github.sha }}
+          path: mfw-offline/
+          if-no-files-found: error
+          compression-level: 0

--- a/.github/workflows/mfw-gmrw-offline-verifier-transport.yml
+++ b/.github/workflows/mfw-gmrw-offline-verifier-transport.yml
@@ -1,0 +1,118 @@
+name: MFW GMRW Offline Verifier Transport
+
+on:
+  push:
+    branches:
+      - agent/mfw-gmrw-offline-verifier-transport
+  pull_request:
+    paths:
+      - '.github/workflows/mfw-gmrw-offline-verifier-transport.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mfw-gmrw-offline-verifier-transport-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  manufacture:
+    name: transport/offline-verifier-toolchain
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout exact ggen authority
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: seanchatmangpt/ggen
+          ref: dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59
+          fetch-depth: 0
+
+      - name: Install exact MFW Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup toolchain install 1.82.0 --profile minimal --component rustfmt,clippy
+          rustup run 1.82.0 rustc --version --verbose
+          rustup run 1.82.0 cargo --version
+          rustup run 1.82.0 rustfmt --version
+          rustup run 1.82.0 cargo clippy --version
+
+      - name: Build exact ggen actuator
+        uses: ./.github/actions/setup-ggen-build
+        with:
+          cache-key-suffix: mfw-gmrw-offline-transport
+
+      - name: Compile ggen
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release -p ggen-cli-lib --bin ggen
+          target/release/ggen --version
+
+      - name: Materialize exact MFW dependency closure
+        shell: bash
+        env:
+          CARGO_HOME: ${{ runner.temp }}/mfw-cargo-home
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/mfw-deps/src "$CARGO_HOME"
+          cat > /tmp/mfw-deps/Cargo.toml <<'TOML'
+          [package]
+          name = "mfw-gmrw-offline-deps"
+          version = "0.0.0"
+          edition = "2021"
+          rust-version = "1.82"
+
+          [dependencies]
+          blake3 = "=1.8.2"
+          serde = { version = "=1.0.228", features = ["derive"] }
+          serde_json = "=1.0.150"
+          thiserror = "=2.0.18"
+          TOML
+          printf 'fn main() {}\n' > /tmp/mfw-deps/src/main.rs
+          rustup run 1.82.0 cargo generate-lockfile --manifest-path /tmp/mfw-deps/Cargo.toml
+          rustup run 1.82.0 cargo fetch --locked --manifest-path /tmp/mfw-deps/Cargo.toml
+          rustup run 1.82.0 cargo check --locked --manifest-path /tmp/mfw-deps/Cargo.toml
+
+      - name: Manufacture portable bundle and receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/mfw-gmrw-offline-toolchain"
+          mkdir -p "$bundle/toolchain" "$bundle/cargo-home" "$bundle/bin" "$bundle/closure"
+          toolchain="$(rustup toolchain list -v | awk '$1 ~ /^1\.82\.0/ {print $NF; exit}')"
+          test -n "$toolchain"
+          cp -a "$toolchain"/. "$bundle/toolchain/"
+          cp -a "$RUNNER_TEMP/mfw-cargo-home"/. "$bundle/cargo-home/"
+          cp target/release/ggen "$bundle/bin/ggen"
+          cp /tmp/mfw-deps/Cargo.toml /tmp/mfw-deps/Cargo.lock "$bundle/closure/"
+          cat > "$bundle/activate.sh" <<'SH'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+          export PATH="$root/toolchain/bin:$root/bin:$PATH"
+          export LD_LIBRARY_PATH="$root/toolchain/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+          export CARGO_HOME="$root/cargo-home"
+          export CARGO_NET_OFFLINE=true
+          SH
+          chmod +x "$bundle/activate.sh"
+          (
+            cd "$bundle"
+            find . -type f ! -name MANIFEST.sha256 -print0 | sort -z | xargs -0 sha256sum > MANIFEST.sha256
+          )
+          tar --sort=name --mtime='UTC 2026-07-31' --owner=0 --group=0 --numeric-owner \
+            -I 'zstd -19 -T0' -cf "$RUNNER_TEMP/mfw-gmrw-offline-toolchain.tar.zst" \
+            -C "$RUNNER_TEMP" mfw-gmrw-offline-toolchain
+          sha256sum "$RUNNER_TEMP/mfw-gmrw-offline-toolchain.tar.zst" > "$RUNNER_TEMP/mfw-gmrw-offline-toolchain.tar.zst.sha256"
+
+      - name: Upload generic verifier toolchain
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mfw-gmrw-offline-toolchain-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/mfw-gmrw-offline-toolchain.tar.zst
+            ${{ runner.temp }}/mfw-gmrw-offline-toolchain.tar.zst.sha256
+          if-no-files-found: error
+          compression-level: 0

--- a/.github/workflows/mfw-gmrw-offline-verifier-transport.yml
+++ b/.github/workflows/mfw-gmrw-offline-verifier-transport.yml
@@ -1,9 +1,6 @@
 name: MFW GMRW Offline Verifier Transport
 
 on:
-  push:
-    branches:
-      - agent/mfw-gmrw-offline-verifier-transport
   pull_request:
     paths:
       - '.github/workflows/mfw-gmrw-offline-verifier-transport.yml'
@@ -17,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  manufacture:
-    name: transport/offline-verifier-toolchain
+  linux-toolchain:
+    name: transport/linux-toolchain
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -114,5 +111,142 @@ jobs:
           path: |
             ${{ runner.temp }}/mfw-gmrw-offline-toolchain.tar.zst
             ${{ runner.temp }}/mfw-gmrw-offline-toolchain.tar.zst.sha256
+          if-no-files-found: error
+          compression-level: 0
+
+  windows-source:
+    name: transport/windows-source
+    runs-on: windows-2025
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout exact ggen source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: seanchatmangpt/ggen
+          ref: dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59
+          fetch-depth: 1
+          path: mfw-offline/src/ggen
+
+      - name: Seal exact sibling source graph
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = "$env:GITHUB_WORKSPACE\mfw-offline\src"
+          $repos = @(
+            @{ Name = 'lsp-max'; Sha = '7bcc1e16dec71ef5fb2cedea2dfd6cb5cde37f59' },
+            @{ Name = 'lsp-types-max'; Sha = '6773e6017ca83c565785d0ec39d75304f62c3237' },
+            @{ Name = 'wasm4pm'; Sha = '0bb134b29245517ac4969a9f1916f5432931c5d0' },
+            @{ Name = 'wasm4pm-compat'; Sha = 'e46155e209a750fda0218532d96ae17a9e10903e' }
+          )
+          foreach ($entry in $repos) {
+            $dest = Join-Path $root $entry.Name
+            git init -q $dest
+            git -C $dest remote add origin "https://github.com/seanchatmangpt/$($entry.Name).git"
+            git -C $dest fetch -q --depth 1 origin $entry.Sha
+            git -C $dest checkout -q FETCH_HEAD
+            $actual = git -C $dest rev-parse HEAD
+            if ($actual -ne $entry.Sha) { throw "source seal mismatch for $($entry.Name): $actual" }
+          }
+          $ggen = git -C (Join-Path $root 'ggen') rev-parse HEAD
+          if ($ggen -ne 'dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59') { throw "ggen seal mismatch: $ggen" }
+
+      - name: Install exact ggen build toolchain
+        run: |
+          $ErrorActionPreference = 'Stop'
+          rustup toolchain install nightly-2026-06-22 --profile minimal
+          rustup run nightly-2026-06-22 rustc --version --verbose
+          rustup run nightly-2026-06-22 cargo --version
+
+      - name: Vendor exact ggen dependency graph
+        env:
+          RUSTC_WRAPPER: ''
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundle = "$env:GITHUB_WORKSPACE\mfw-offline"
+          $ggen = "$bundle\src\ggen"
+          Push-Location $ggen
+          try {
+            $config = rustup run nightly-2026-06-22 cargo vendor --locked "$bundle\ggen-vendor"
+            [System.IO.File]::WriteAllLines("$bundle\ggen-vendor-config.toml", $config)
+          } finally {
+            Pop-Location
+          }
+
+      - name: Vendor exact MFW dependency closure
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $bundle = "$env:GITHUB_WORKSPACE\mfw-offline"
+          $closure = "$bundle\mfw-closure"
+          New-Item -ItemType Directory -Force -Path "$closure\src" | Out-Null
+          @'
+          [package]
+          name = "mfw-gmrw-offline-deps"
+          version = "0.0.0"
+          edition = "2021"
+          rust-version = "1.82"
+
+          [dependencies]
+          blake3 = "=1.8.2"
+          serde = { version = "=1.0.228", features = ["derive"] }
+          serde_json = "=1.0.150"
+          thiserror = "=2.0.18"
+          '@ | Set-Content -Encoding utf8 "$closure\Cargo.toml"
+          'fn main() {}' | Set-Content -Encoding utf8 "$closure\src\main.rs"
+          rustup run nightly-2026-06-22 cargo generate-lockfile --manifest-path "$closure\Cargo.toml"
+          $config = rustup run nightly-2026-06-22 cargo vendor --locked --manifest-path "$closure\Cargo.toml" "$bundle\mfw-vendor"
+          [System.IO.File]::WriteAllLines("$bundle\mfw-vendor-config.toml", $config)
+
+      - name: Download exact Linux toolchains
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $dest = "$env:GITHUB_WORKSPACE\mfw-offline\toolchains"
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          $assets = @(
+            'https://static.rust-lang.org/dist/rust-1.82.0-x86_64-unknown-linux-gnu.tar.xz',
+            'https://static.rust-lang.org/dist/2026-06-22/rust-nightly-x86_64-unknown-linux-gnu.tar.xz'
+          )
+          foreach ($url in $assets) {
+            $name = Split-Path $url -Leaf
+            $path = Join-Path $dest $name
+            Invoke-WebRequest -Uri $url -OutFile $path
+            Invoke-WebRequest -Uri "$url.sha256" -OutFile "$path.sha256"
+            $expected = ((Get-Content "$path.sha256") -split '\s+')[0].ToLowerInvariant()
+            $actual = (Get-FileHash -Algorithm SHA256 $path).Hash.ToLowerInvariant()
+            if ($actual -ne $expected) { throw "SHA-256 mismatch for $name" }
+          }
+
+      - name: Remove Git transport metadata
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Get-ChildItem "$env:GITHUB_WORKSPACE\mfw-offline\src" -Directory -Recurse -Force -Filter .git |
+            Sort-Object FullName -Descending |
+            Remove-Item -Recurse -Force
+
+      - name: Manufacture deterministic manifest
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = "$env:GITHUB_WORKSPACE\mfw-offline"
+          $records = Get-ChildItem $root -File -Recurse | Sort-Object FullName | ForEach-Object {
+            [ordered]@{
+              path = $_.FullName.Substring($root.Length + 1).Replace('\', '/')
+              bytes = $_.Length
+              sha256 = (Get-FileHash -Algorithm SHA256 $_.FullName).Hash.ToLowerInvariant()
+            }
+          }
+          [ordered]@{
+            schema = 'mfw.gmrw.offline-source-bundle.v1'
+            ggen_revision = 'dc9daf2b2a6f5b8991e75b7f3b715a3203f90d59'
+            rust_stable = '1.82.0'
+            rust_nightly = 'nightly-2026-06-22'
+            files = $records
+          } | ConvertTo-Json -Depth 5 | Set-Content -Encoding utf8 "$root\MANIFEST.json"
+
+      - name: Upload sealed offline source bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mfw-gmrw-offline-source-${{ github.sha }}
+          path: mfw-offline/
           if-no-files-found: error
           compression-level: 0

--- a/.github/workflows/mfw-gmrw-slim-toolchains.yml
+++ b/.github/workflows/mfw-gmrw-slim-toolchains.yml
@@ -1,0 +1,51 @@
+name: MFW GMRW Slim Toolchain Transport
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/mfw-gmrw-slim-toolchains.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mfw-gmrw-slim-toolchains-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  toolchains:
+    name: transport/slim-linux-toolchains
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    steps:
+      - name: Download and verify exact Linux toolchains
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/toolchains"
+          assets=(
+            'https://static.rust-lang.org/dist/rust-1.82.0-x86_64-unknown-linux-gnu.tar.xz'
+            'https://static.rust-lang.org/dist/2026-06-22/rust-nightly-x86_64-unknown-linux-gnu.tar.xz'
+          )
+          for url in "${assets[@]}"; do
+            name="${url##*/}"
+            curl --fail --location --retry 3 --output "$RUNNER_TEMP/toolchains/$name" "$url"
+            curl --fail --location --retry 3 --output "$RUNNER_TEMP/toolchains/$name.sha256" "$url.sha256"
+            (
+              cd "$RUNNER_TEMP/toolchains"
+              sha256sum --check "$name.sha256"
+            )
+          done
+          (
+            cd "$RUNNER_TEMP/toolchains"
+            sha256sum *.tar.xz > MANIFEST.sha256
+          )
+
+      - name: Upload exact Linux toolchains
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mfw-gmrw-linux-toolchains-${{ github.sha }}
+          path: ${{ runner.temp }}/toolchains/
+          if-no-files-found: error
+          compression-level: 0


### PR DESCRIPTION
Temporary generic verifier transport for private MFW PR #47. It checks out exact public ggen authority and uploads Rust 1.82, ggen, and the exact PCP dependency closure. No MFW source or private data enter this public repository. Not intended for merge.