### PR TITLE
docs: document Forward Deployment portfolio context

### DIFF
--- a/FORWARD_DEPLOYMENT.md
+++ b/FORWARD_DEPLOYMENT.md
@@ -1,0 +1,7 @@
+# Forward Deployment Portfolio Context
+
+Part of Sean Chatman’s portfolio around **The 2,001st Forward-Deployed Agentic Architect** and the **Chatman Ecosystem: the operating system for forward deployment**.
+
+Existing README, provenance, authorship, license, governance, purpose, and maturity statements remain authoritative. Inclusion does not assert original authorship, complete integration, production standing, or ambient execution authority.
+
+Standing requires exact observed execution against admitted inputs, bounded verification, and receipts.


### PR DESCRIPTION
Documentation-only draft. Adds portfolio context while preserving existing provenance, authorship, licensing, purpose, governance, and maturity statements. No code, workflow, dependency, test, build, release, permission, or security behavior changes.